### PR TITLE
Add page title to the HTML generated by PHP

### DIFF
--- a/src/Content/Page.php
+++ b/src/Content/Page.php
@@ -58,6 +58,8 @@ class Page
 
         $apiDocument = $this->getApiDocument($request, $id);
 
+        $document->title = $apiDocument->data->attributes->title;
+
         $document->content = $this->view->make('fof-pages::content.page', compact('apiDocument'));
 
         $document->payload['apiDocument'] = $apiDocument;


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes**
The page title is wrong before JavaScript loaded.

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
Set document title in the page controller before page generating start.

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->
before:
<img width="379" alt="image" src="https://user-images.githubusercontent.com/9024954/156863231-2a1bd56a-f7a8-4005-8fc4-1078005ca74a.png">

after:
<img width="368" alt="image" src="https://user-images.githubusercontent.com/9024954/156863181-6c6b70d6-3522-45bf-98b2-245b82e3cc2a.png">


