### PR TITLE
Adjust margin-bottom for paragraphs and list items

### DIFF
--- a/resources/less/forum.less
+++ b/resources/less/forum.less
@@ -2,6 +2,7 @@
   .PageHero {
     margin-bottom: 20px;
   }
+
   .PageHero-items {
     padding: 0;
     margin: 0;
@@ -11,6 +12,7 @@
       display: inline-block;
     }
   }
+
   .PageHero-title {
     > a {
       //color: @hero-color;
@@ -18,7 +20,6 @@
     display: inline;
     vertical-align: middle;
   }
-
 
   .Pages-container {
     max-width: 820px;
@@ -29,5 +30,12 @@
     .Post-body {
       white-space: normal;
     }
+  }
+
+  //Reverse duplicate margin-bottom
+  p,
+  ul li,
+  ol li {
+    margin-bottom: -1em;
   }
 }


### PR DESCRIPTION
**Changes proposed in this pull request:**
Added negative margin-bottom to paragraphs and list items. Due to Flarum's general LESS/CSS and how this extension works, pages end up with duplicate bottom margin for paragraphs and lists. By adding negative bottom margin, we reverse this. Now there is a normal amount of paragraph and list spacing for pages. This only targets pages; does not affect the rest of the forum.

**Reviewers should focus on:**
Installing this extension with and without the negative margin-bottom to see the difference.

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- Backend changes: none.
